### PR TITLE
add py.typed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,5 +28,8 @@ setuptools.setup(
         'development'
     ],
     packages=setuptools.find_packages(exclude=["tests*"]),
+    package_data = {
+        'aws_lambda_typing': ['py.typed'],
+    },
     python_requires='>=3.8',
 )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="aws-lambda-typing",
-    version="1.0.2",
+    version="1.0.3",
     description="A package that provides type hints for AWS Lambda event, context and response objects",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
I added `py.typed`.

I saw the following error messages from mypy because `py.typed` is missing.
```
error: Skipping analyzing 'aws_lambda_typing': found module but no type hints or library stubs  [import]
note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
```

[more detail](https://github.com/curekoshimizu/issue_report_aws_lambda_typing#how-to-use)

ref. what is py.typed?
https://www.python.org/dev/peps/pep-0561/#id18


