### PR TITLE
Fix APIGatewayProxyResponseV2

### DIFF
--- a/aws_lambda_typing/responses/api_gateway_proxy.py
+++ b/aws_lambda_typing/responses/api_gateway_proxy.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import sys
+from typing import Any, Union
 
 if sys.version_info >= (3, 8):
     from typing import Dict, List, TypedDict
@@ -50,7 +51,7 @@ class APIGatewayProxyResponseV1(TypedDict):
 """
 
 
-class APIGatewayProxyResponseV2(TypedDict):
+class _APIGatewayProxyResponseV2(TypedDict, total=False):
     """
     APIGatewayProxyResponseV2 https://docs.aws.amazon.com/lambda/latest/dg/services-apigateway.html
 
@@ -74,3 +75,10 @@ class APIGatewayProxyResponseV2(TypedDict):
     statusCode: int
     headers: Dict[str, str]
     body: str
+
+
+APIGatewayProxyResponseV2 = Union[
+    _APIGatewayProxyResponseV2,
+    dict[str, Any],
+    str,
+]

--- a/aws_lambda_typing/responses/api_gateway_proxy.py
+++ b/aws_lambda_typing/responses/api_gateway_proxy.py
@@ -77,8 +77,13 @@ class _APIGatewayProxyResponseV2(TypedDict, total=False):
     body: str
 
 
+SimpleJSON = Union[
+    str,
+    List["SimpleJSON"],
+    Dict[str, "SimpleJSON"],
+]
+
 APIGatewayProxyResponseV2 = Union[
     _APIGatewayProxyResponseV2,
-    dict[str, Any],
-    str,
+    SimpleJSON
 ]


### PR DESCRIPTION
In v2, all fields can be omitted and when all are omitted, we can pass `str`, `dict`, `list`, etc... which will be converted to `body`.