### PR TITLE
Correct casing of attribute on KinesisStreamEvent

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-lambda-typing"
-version = "2.8.0"
+version = "2.8.1"
 description = "A package that provides type hints for AWS Lambda event, context and response objects"
 authors = ["Mousa Zeid Baker"]
 license = "MIT"

--- a/src/aws_lambda_typing/events/kinesis_stream.py
+++ b/src/aws_lambda_typing/events/kinesis_stream.py
@@ -74,7 +74,7 @@ class KinesisStreamEvent(TypedDict):
 
     Attributes:
     ----------
-    records: List[:py:class:`KinesisStreamRecord`]
+    Records: List[:py:class:`KinesisStreamRecord`]
     """
 
-    records: List[KinesisStreamRecord]
+    Records: List[KinesisStreamRecord]

--- a/tests/events/test_kinesis_stream.py
+++ b/tests/events/test_kinesis_stream.py
@@ -3,7 +3,7 @@ from aws_lambda_typing.events import KinesisStreamEvent
 
 def test_kinesis_stream_event() -> None:
     event: KinesisStreamEvent = {
-        "records": [
+        "Records": [
             {
                 "kinesis": {
                     "kinesisSchemaVersion": "1.0",


### PR DESCRIPTION
The `Records` attribute is title-cased, going against what AWS otherwise do everywhere else.