### PR TITLE
Add event type for cognito CustomMessage

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ def handler(event: events.SQSEvent, context: context_.Context) -> None:
 - CloudWatchLogsEvent
 - CodeCommitMessageEvent
 - CodePipelineEvent
+- CognitoCustomMessageEvent
 - ConfigEvent
 - DynamoDBStreamEvent
 - EventBridgeEvent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-lambda-typing"
-version = "2.10.1"
+version = "2.12.0"
 description = "A package that provides type hints for AWS Lambda event, context and response objects"
 authors = ["Mousa Zeid Baker"]
 license = "MIT"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
 max-line-length = 80
 per-file-ignores =
-    __init__.py:F401
+    __init__.py:F401,E501
     test*.py:F841

--- a/src/aws_lambda_typing/events/__init__.py
+++ b/src/aws_lambda_typing/events/__init__.py
@@ -26,6 +26,7 @@ from .cloud_watch_events import (
 from .cloud_watch_logs import CloudWatchLogsEvent as CloudWatchLogsEvent
 from .code_commit import CodeCommitMessageEvent as CodeCommitMessageEvent
 from .code_pipeline import CodePipelineEvent as CodePipelineEvent
+from .cognito_custom_message import CognitoCustomMessage as CognitoCustomMessage
 from .config import ConfigEvent as ConfigEvent
 from .dynamodb_stream import DynamoDBStreamEvent as DynamoDBStreamEvent
 from .event_bridge import EventBridgeEvent as EventBridgeEvent

--- a/src/aws_lambda_typing/events/__init__.py
+++ b/src/aws_lambda_typing/events/__init__.py
@@ -26,7 +26,30 @@ from .cloud_watch_events import (
 from .cloud_watch_logs import CloudWatchLogsEvent as CloudWatchLogsEvent
 from .code_commit import CodeCommitMessageEvent as CodeCommitMessageEvent
 from .code_pipeline import CodePipelineEvent as CodePipelineEvent
-from .cognito_custom_message import CognitoCustomMessage as CognitoCustomMessage
+from .cognito_custom_message import (
+    CognitoCustomMessageAdminCreateUserEvent as CognitoCustomMessageAdminCreateUserEvent,
+)
+from .cognito_custom_message import (
+    CognitoCustomMessageAuthenticationEvent as CognitoCustomMessageAuthenticationEvent,
+)
+from .cognito_custom_message import (
+    CognitoCustomMessageEvent as CognitoCustomMessageEvent,
+)
+from .cognito_custom_message import (
+    CognitoCustomMessageForgotPasswordEvent as CognitoCustomMessageForgotPasswordEvent,
+)
+from .cognito_custom_message import (
+    CognitoCustomMessageResendCodeEvent as CognitoCustomMessageResendCodeEvent,
+)
+from .cognito_custom_message import (
+    CognitoCustomMessageSignUpEvent as CognitoCustomMessageSignUpEvent,
+)
+from .cognito_custom_message import (
+    CognitoCustomMessageUpdateUserAttributeEvent as CognitoCustomMessageUpdateUserAttributeEvent,
+)
+from .cognito_custom_message import (
+    CognitoCustomMessageVerifyUserAttributeEvent as CognitoCustomMessageVerifyUserAttributeEvent,
+)
 from .config import ConfigEvent as ConfigEvent
 from .dynamodb_stream import DynamoDBStreamEvent as DynamoDBStreamEvent
 from .event_bridge import EventBridgeEvent as EventBridgeEvent

--- a/src/aws_lambda_typing/events/cognito_custom_message.py
+++ b/src/aws_lambda_typing/events/cognito_custom_message.py
@@ -1,61 +1,62 @@
 #!/usr/bin/env python
 
 import sys
-from typing import Literal
 
 if sys.version_info >= (3, 8):
-    from typing import Dict, Optional, TypedDict
+    from typing import Any, Dict, Literal, Optional, TypedDict, Union
 else:
-    from typing import Dict, Optional
+    from typing import Any, Dict, Optional, Union
 
-    from typing_extensions import TypedDict
+    from typing_extensions import Literal, TypedDict
 
 
-class CognitoCustomMessageCallerContext(TypedDict):
+class CallerContext(TypedDict):
     """
-    CognitoCustomMessageCallerContext
+    CallerContext
 
     Attributes:
     ----------:
-    awsSdk: str
+    awsSdkVersion: str
+
     clientId: str
     """
 
-    awsSdk: str
+    awsSdkVersion: str
     clientId: str
 
 
-class CognitoCustomMessageRequestUserAttributes(TypedDict):
+class Request(TypedDict, total=False):
     """
-    CognitoCustomMessageRequestUserAttributes
+    Request
 
     Attributes:
     ----------:
-    phone_number_verified: bool
-    email_verified: bool
+    userAttributes: Dict[str, Any]
+
+    codeParameter: str
+
+    usernameParameter: str
+
+    clientMetadata: Optional[Dict[str, Any]]
     """
 
-    phone_number_verified: bool
-    email_verified: bool
+    userAttributes: Dict[str, Any]
+    codeParameter: str
+    usernameParameter: str
+    clientMetadata: Optional[Dict[str, Any]]
 
 
-class CognitoCustomMessageRequest(TypedDict):
+class Response(TypedDict):
     """
-    CognitoCustomMessageRequest
+    Response
 
     Attributes:
     ----------:
-    userAttributes: CognitoCustomMessageRequestUserAttributes
-    """
+    smsMessage: str
 
+    emailMessage: str
 
-class CognitoCustomMessageResponse(TypedDict):
-    """
-    CognitoCustomMessageResponse
-
-    Attributes:
-    ----------:
-    userAttributes: CognitoCustomMessageRequestUserAttributes
+    emailSubject: str
     """
 
     smsMessage: str
@@ -63,26 +64,178 @@ class CognitoCustomMessageResponse(TypedDict):
     emailSubject: str
 
 
-class CognitoCustomMessage(TypedDict):
+class CognitoCustomMessageCommon(TypedDict):
     """
-    CognitoCustomMessage
+    CognitoCustomMessageCommon
+    https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-identity-pools-working-with-aws-lambda-triggers.html#cognito-user-pools-lambda-trigger-syntax-shared
+
+    Attributes:
+    ----------
+    version: str
+
+    region: str
+
+    userPoolId: str
+
+    userName: str
+
+    callerContext: :py:class:`CallerContext`
+
+    request: :py:class:`Request`
+
+    response: :py:class:`Response`
+    """
+
+    version: str
+    region: str
+    userPoolId: str
+    userName: str
+    callerContext: CallerContext
+    request: Request
+    response: Response
+
+
+class CognitoCustomMessageSignUpEvent(
+    CognitoCustomMessageCommon,
+):
+    """
+    CognitoCustomMessageSignUpEvent
     https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-custom-message.html
 
     Attributes:
     ----------
-    triggerSource: str
+    triggerSource: Literal['CustomMessage_SignUp']
     """
 
-    version: int
-    triggerSource: Literal[
-        "CustomMessage_SignUp",
-        "CustomMessage_ResendCode",
-        "CustomMessage_ForgotPassword",
-        "CustomMessage_VerifyUserAttribute",
-    ]
-    region: str
-    userPoolId: str
-    userName: str
-    callerContext: CognitoCustomMessageCallerContext
-    request: CognitoCustomMessageRequest
-    response: CognitoCustomMessageResponse
+    triggerSource: Literal["CustomMessage_SignUp"]
+
+
+class CognitoCustomMessageAdminCreateUserEvent(
+    CognitoCustomMessageCommon,
+):
+    """
+    CognitoCustomMessageAdminCreateUserEvent
+    https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-custom-message.html
+
+    Attributes:
+    ----------
+    triggerSource: Literal['CustomMessage_AdminCreateUser']
+    """
+
+    triggerSource: Literal["CustomMessage_AdminCreateUser"]
+
+
+class CognitoCustomMessageResendCodeEvent(
+    CognitoCustomMessageCommon,
+):
+    """
+    CognitoCustomMessageResendCodeEvent
+    https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-custom-message.html
+
+    Attributes:
+    ----------
+    triggerSource: Literal['CustomMessage_ResendCode']
+    """
+
+    triggerSource: Literal["CustomMessage_ResendCode"]
+
+
+class CognitoCustomMessageForgotPasswordEvent(
+    CognitoCustomMessageCommon,
+):
+    """
+    CognitoCustomMessageForgotPasswordEvent
+    https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-custom-message.html
+
+    Attributes:
+    ----------
+    triggerSource: Literal['CustomMessage_ForgotPassword']
+    """
+
+    triggerSource: Literal["CustomMessage_ForgotPassword"]
+
+
+class CognitoCustomMessageUpdateUserAttributeEvent(
+    CognitoCustomMessageCommon,
+):
+    """
+    CognitoCustomMessageUpdateUserAttributeEvent
+    https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-custom-message.html
+
+    Attributes:
+    ----------
+    triggerSource: Literal['CustomMessage_UpdateUserAttribute']
+    """
+
+    triggerSource: Literal["CustomMessage_UpdateUserAttribute"]
+
+
+class CognitoCustomMessageVerifyUserAttributeEvent(
+    CognitoCustomMessageCommon,
+):
+    """
+    CognitoCustomMessageVerifyUserAttributeEvent
+    https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-custom-message.html
+
+    Attributes:
+    ----------
+    triggerSource: Literal['CustomMessage_VerifyUserAttribute']
+    """
+
+    triggerSource: Literal["CustomMessage_VerifyUserAttribute"]
+
+
+class CognitoCustomMessageAuthenticationEvent(
+    CognitoCustomMessageCommon,
+):
+    """
+    CognitoCustomMessageAuthenticationEvent
+    https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-custom-message.html
+
+    Attributes:
+    ----------
+    triggerSource: Literal['CustomMessage_Authentication']
+    """
+
+    triggerSource: Literal["CustomMessage_Authentication"]
+
+
+CognitoCustomMessageEvent = Union[
+    CognitoCustomMessageSignUpEvent,
+    CognitoCustomMessageAdminCreateUserEvent,
+    CognitoCustomMessageResendCodeEvent,
+    CognitoCustomMessageForgotPasswordEvent,
+    CognitoCustomMessageUpdateUserAttributeEvent,
+    CognitoCustomMessageVerifyUserAttributeEvent,
+    CognitoCustomMessageAuthenticationEvent,
+]
+"""
+CognitoCustomMessageEvent
+https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-custom-message.html
+
+Attributes:
+----------
+version: str
+
+triggerSource: Literal[
+    "CustomMessage_SignUp",
+    "CustomMessage_AdminCreateUser",
+    "CustomMessage_ResendCode",
+    "CustomMessage_ForgotPassword",
+    "CustomMessage_UpdateUserAttribute",
+    "CustomMessage_VerifyUserAttribute",
+    "CustomMessage_Authentication"
+]
+
+region: str
+
+userPoolId: str
+
+userName: str
+
+callerContext: :py:class:`CallerContext`
+
+request: :py:class:`Request`
+
+response: :py:class:`Response`
+"""

--- a/src/aws_lambda_typing/events/cognito_custom_message.py
+++ b/src/aws_lambda_typing/events/cognito_custom_message.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+
+import sys
+from typing import Literal
+
+if sys.version_info >= (3, 8):
+    from typing import Dict, Optional, TypedDict
+else:
+    from typing import Dict, Optional
+
+    from typing_extensions import TypedDict
+
+
+class CognitoCustomMessageCallerContext(TypedDict):
+    """
+    CognitoCustomMessageCallerContext
+
+    Attributes:
+    ----------:
+    awsSdk: str
+    clientId: str
+    """
+
+    awsSdk: str
+    clientId: str
+
+
+class CognitoCustomMessageRequestUserAttributes(TypedDict):
+    """
+    CognitoCustomMessageRequestUserAttributes
+
+    Attributes:
+    ----------:
+    phone_number_verified: bool
+    email_verified: bool
+    """
+
+    phone_number_verified: bool
+    email_verified: bool
+
+
+class CognitoCustomMessageRequest(TypedDict):
+    """
+    CognitoCustomMessageRequest
+
+    Attributes:
+    ----------:
+    userAttributes: CognitoCustomMessageRequestUserAttributes
+    """
+
+
+class CognitoCustomMessageResponse(TypedDict):
+    """
+    CognitoCustomMessageResponse
+
+    Attributes:
+    ----------:
+    userAttributes: CognitoCustomMessageRequestUserAttributes
+    """
+
+    smsMessage: str
+    emailMessage: str
+    emailSubject: str
+
+
+class CognitoCustomMessage(TypedDict):
+    """
+    CognitoCustomMessage
+    https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-custom-message.html
+
+    Attributes:
+    ----------
+    triggerSource: str
+    """
+
+    version: int
+    triggerSource: Literal[
+        "CustomMessage_SignUp",
+        "CustomMessage_ResendCode",
+        "CustomMessage_ForgotPassword",
+        "CustomMessage_VerifyUserAttribute",
+    ]
+    region: str
+    userPoolId: str
+    userName: str
+    callerContext: CognitoCustomMessageCallerContext
+    request: CognitoCustomMessageRequest
+    response: CognitoCustomMessageResponse

--- a/tests/events/test_cognito_custom_message.py
+++ b/tests/events/test_cognito_custom_message.py
@@ -1,0 +1,27 @@
+from aws_lambda_typing.events import CognitoCustomMessage
+
+
+def test_cognito_custom_message_event() -> None:
+    event: CognitoCustomMessage = {
+        "version": 1,
+        "triggerSource": "CustomMessage_SignUp",
+        "region": "us-west-2",
+        "userPoolId": "poolid",
+        "userName": "userName",
+        "callerContext": {
+            "awsSdk": "1",
+            "clientId": "jkSDFasdfnsq",
+        },
+        "request": {
+            "userAttributes": {
+                "phone_number_verified": False,
+                "email_verified": True,
+            },
+            "codeParameter": "####",
+        },
+        "response": {
+            "smsMessage": "<custom message to be sent in the message with code parameter>",
+            "emailMessage": "<custom message to be sent in the message with code parameter>",
+            "emailSubject": "<custom email subject>",
+        },
+    }

--- a/tests/events/test_cognito_custom_message.py
+++ b/tests/events/test_cognito_custom_message.py
@@ -1,15 +1,23 @@
-from aws_lambda_typing.events import CognitoCustomMessage
+from aws_lambda_typing.events import (
+    CognitoCustomMessageAdminCreateUserEvent,
+    CognitoCustomMessageAuthenticationEvent,
+    CognitoCustomMessageForgotPasswordEvent,
+    CognitoCustomMessageResendCodeEvent,
+    CognitoCustomMessageSignUpEvent,
+    CognitoCustomMessageUpdateUserAttributeEvent,
+    CognitoCustomMessageVerifyUserAttributeEvent,
+)
 
 
-def test_cognito_custom_message_event() -> None:
-    event: CognitoCustomMessage = {
-        "version": 1,
+def test_cognito_custom_message_sign_up_event() -> None:
+    event: CognitoCustomMessageSignUpEvent = {
+        "version": "1",
         "triggerSource": "CustomMessage_SignUp",
         "region": "us-west-2",
         "userPoolId": "poolid",
         "userName": "userName",
         "callerContext": {
-            "awsSdk": "1",
+            "awsSdkVersion": "1",
             "clientId": "jkSDFasdfnsq",
         },
         "request": {
@@ -20,8 +28,164 @@ def test_cognito_custom_message_event() -> None:
             "codeParameter": "####",
         },
         "response": {
-            "smsMessage": "<custom message to be sent in the message with code parameter>",
-            "emailMessage": "<custom message to be sent in the message with code parameter>",
+            "smsMessage": "<custom message to be sent in the message with code parameter>",  # noqa: E501
+            "emailMessage": "<custom message to be sent in the message with code parameter>",  # noqa: E501
+            "emailSubject": "<custom email subject>",
+        },
+    }
+
+
+def test_cognito_custom_message_admin_create_user_event() -> None:
+    event: CognitoCustomMessageAdminCreateUserEvent = {
+        "version": "1",
+        "triggerSource": "CustomMessage_AdminCreateUser",
+        "region": "us-west-2",
+        "userPoolId": "poolid",
+        "userName": "userName",
+        "callerContext": {
+            "awsSdkVersion": "1",
+            "clientId": "jkSDFasdfnsq",
+        },
+        "request": {
+            "userAttributes": {
+                "phone_number_verified": False,
+                "email_verified": True,
+            },
+            "codeParameter": "####",
+        },
+        "response": {
+            "smsMessage": "<custom message to be sent in the message with code parameter>",  # noqa: E501
+            "emailMessage": "<custom message to be sent in the message with code parameter>",  # noqa: E501
+            "emailSubject": "<custom email subject>",
+        },
+    }
+
+
+def test_cognito_custom_message_resend_code_event() -> None:
+    event: CognitoCustomMessageResendCodeEvent = {
+        "version": "1",
+        "triggerSource": "CustomMessage_ResendCode",
+        "region": "us-west-2",
+        "userPoolId": "poolid",
+        "userName": "userName",
+        "callerContext": {
+            "awsSdkVersion": "1",
+            "clientId": "jkSDFasdfnsq",
+        },
+        "request": {
+            "userAttributes": {
+                "phone_number_verified": False,
+                "email_verified": True,
+            },
+            "codeParameter": "####",
+        },
+        "response": {
+            "smsMessage": "<custom message to be sent in the message with code parameter>",  # noqa: E501
+            "emailMessage": "<custom message to be sent in the message with code parameter>",  # noqa: E501
+            "emailSubject": "<custom email subject>",
+        },
+    }
+
+
+def test_cognito_custom_message_forgot_password_event() -> None:
+    event: CognitoCustomMessageForgotPasswordEvent = {
+        "version": "1",
+        "triggerSource": "CustomMessage_ForgotPassword",
+        "region": "us-west-2",
+        "userPoolId": "poolid",
+        "userName": "userName",
+        "callerContext": {
+            "awsSdkVersion": "1",
+            "clientId": "jkSDFasdfnsq",
+        },
+        "request": {
+            "userAttributes": {
+                "phone_number_verified": False,
+                "email_verified": True,
+            },
+            "codeParameter": "####",
+        },
+        "response": {
+            "smsMessage": "<custom message to be sent in the message with code parameter>",  # noqa: E501
+            "emailMessage": "<custom message to be sent in the message with code parameter>",  # noqa: E501
+            "emailSubject": "<custom email subject>",
+        },
+    }
+
+
+def test_cognito_custom_message_update_user_attribute_event() -> None:
+    event: CognitoCustomMessageUpdateUserAttributeEvent = {
+        "version": "1",
+        "triggerSource": "CustomMessage_UpdateUserAttribute",
+        "region": "us-west-2",
+        "userPoolId": "poolid",
+        "userName": "userName",
+        "callerContext": {
+            "awsSdkVersion": "1",
+            "clientId": "jkSDFasdfnsq",
+        },
+        "request": {
+            "userAttributes": {
+                "phone_number_verified": False,
+                "email_verified": True,
+            },
+            "codeParameter": "####",
+        },
+        "response": {
+            "smsMessage": "<custom message to be sent in the message with code parameter>",  # noqa: E501
+            "emailMessage": "<custom message to be sent in the message with code parameter>",  # noqa: E501
+            "emailSubject": "<custom email subject>",
+        },
+    }
+
+
+def test_cognito_custom_message_verify_user_attribute_event() -> None:
+    event: CognitoCustomMessageVerifyUserAttributeEvent = {
+        "version": "1",
+        "triggerSource": "CustomMessage_VerifyUserAttribute",
+        "region": "us-west-2",
+        "userPoolId": "poolid",
+        "userName": "userName",
+        "callerContext": {
+            "awsSdkVersion": "1",
+            "clientId": "jkSDFasdfnsq",
+        },
+        "request": {
+            "userAttributes": {
+                "phone_number_verified": False,
+                "email_verified": True,
+            },
+            "codeParameter": "####",
+        },
+        "response": {
+            "smsMessage": "<custom message to be sent in the message with code parameter>",  # noqa: E501
+            "emailMessage": "<custom message to be sent in the message with code parameter>",  # noqa: E501
+            "emailSubject": "<custom email subject>",
+        },
+    }
+
+
+def test_cognito_custom_message_authentication_event() -> None:
+    event: CognitoCustomMessageAuthenticationEvent = {
+        "version": "1",
+        "triggerSource": "CustomMessage_Authentication",
+        "region": "us-west-2",
+        "userPoolId": "poolid",
+        "userName": "userName",
+        "callerContext": {
+            "awsSdkVersion": "1",
+            "clientId": "jkSDFasdfnsq",
+        },
+        "request": {
+            "userAttributes": {
+                "phone_number_verified": False,
+                "email_verified": True,
+            },
+            "codeParameter": "####",
+        },
+        "response": {
+            "smsMessage": "<custom message to be sent in the message with code parameter>",  # noqa: E501
+            "emailMessage": "<custom message to be sent in the message with code parameter>",  # noqa: E501
             "emailSubject": "<custom email subject>",
         },
     }


### PR DESCRIPTION
These events are used when running a lambda for customizing the SMS / Email sent out during user signup, password reset, etc.

https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-custom-message.html