### PR TITLE
Add websocket events

### DIFF
--- a/src/aws_lambda_typing/events/websocket.py
+++ b/src/aws_lambda_typing/events/websocket.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python
+
+import sys
+
+if sys.version_info >= (3, 8):
+    from typing import Dict, List, Literal, TypedDict
+else:
+    from typing import Dict, List
+
+    from typing_extensions import Literal, TypedDict
+
+
+class Identity(TypedDict, total=False):
+    """
+    Identity
+
+    Attributes:
+    ----------
+    accountId: str
+
+    apiKey: str
+
+    apiKeyId: str
+
+    caller: str
+
+    cognitoAuthenticationProvider: str
+
+    cognitoAuthenticationType: str
+
+    cognitoIdentityId: str
+
+    cognitoIdentityPoolId: str
+
+    sourceIp: str
+
+    user: str
+
+    userAgent: str
+
+    userArn: str
+    """
+    accountId: str
+    apiKey: str
+    apiKeyId: str
+    caller: str
+    cognitoAuthenticationProvider: str
+    cognitoAuthenticationType: str
+    cognitoIdentityId: str
+    cognitoIdentityPoolId: str
+    sourceIp: str
+    user: str
+    userAgent: str
+    userArn: str
+
+
+class Error(TypedDict, total=False):
+    """
+    Error
+
+    Attributes:
+    ----------
+    message: str
+
+    messageString: str
+
+    validationErrorString: str
+    """
+    message: str
+    messageString: str
+    validationErrorString: str
+
+
+class RequestContextRequiredAttributes(TypedDict):
+    """
+    RequestContextRequiredAttributes
+
+    Attributes:
+    ----------
+    connectionId: str
+
+    connectedAt: int
+
+    domainName: str
+
+    eventType: Literal['CONNECT', 'DISCONNECT', 'MESSAGE']
+
+    routeKey: str
+
+    requestId: str
+
+    extendedRequestId: str
+
+    apiId: str
+
+    authorizer: Dict[str, str]
+
+    requestTime: str
+
+    requestTimeEpoch: int
+
+    messageDirection: Literal['IN', 'OUT']
+
+    stage: str
+
+    identity: :py:class:`Identity`
+    """
+    connectionId: str
+    connectedAt: int
+    domainName: str
+    eventType: Literal['CONNECT', 'DISCONNECT', 'MESSAGE']
+    routeKey: str
+    requestId: str
+    extendedRequestId: str
+    apiId: str
+    authorizer: Dict[str, str]
+    requestTime: str
+    requestTimeEpoch: int
+    messageDirection: Literal['IN', 'OUT']
+    stage: str
+    identity: Identity
+
+
+class RequestContext(RequestContextRequiredAttributes, total=False):
+    """
+    Attributes:
+    ----------
+    messageId: str - exists when eventType == 'MESSAGE'
+    error: :py:class:`Error`
+    status: int
+    """
+    messageId: str
+    error: Error
+    status: int
+
+
+class WebSocketEventCommonAttributes(TypedDict):
+    """
+    WebSocketEvent required attributes only
+    https://peps.python.org/pep-0589/#totality
+
+    Attributes:
+    ----------
+    requestContext: :py:class:`RequestContext`
+
+    isBase64Encoded: bool
+    """
+    requestContext: List[RequestContext]
+    isBase64Encoded: bool
+
+
+class WebSocketConnectEvent(WebSocketEventCommonAttributes):
+    """
+    WebSocketEvent https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-mapping-template-reference.html
+    as sent to the $connect and $disconnect routes.
+
+    Attributes:
+    ----------
+    headers: Dict[str, str]
+
+    multiValueHeaders: Dict[str, List[str]]
+
+    queryStringParameters: Dict[str, str]
+
+    multiValueQueryStringParameters: Dict[str, List[str]]
+    """
+    headers: Dict[str, str]
+    multiValueHeaders: Dict[str, List[str]]
+    queryStringParameters: Dict[str, str]
+    multiValueQueryStringParameters: Dict[str, List[str]]
+
+
+class WebSocketRouteEvent(WebSocketEventCommonAttributes):
+    """
+    WebSocketEvent https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-mapping-template-reference.html
+    as send to custom routes and the $default route.
+
+    Attributes:
+    ----------
+    body: str
+    """
+    body: str
+


### PR DESCRIPTION
Add the following events:
* WebSocketConnectEvent - for $connect and $disconnect
* WebSocketRouteEvent - for custom routes and $default

Websocket event resources:
https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api.html
https://www.serverless.com/framework/docs/providers/aws/events/websocket#example-serverlessyaml


Event examples:
### connet:
```js
{
  'headers': {
    'Host': 'ws.domain.io',
    'Sec-WebSocket-Extensions': 'permessage-deflate; client_max_window_bits',
    'Sec-WebSocket-Key': 'NysmUTUM1SWo5oeJuKHZhw==',
    'Sec-WebSocket-Version': '13',
    'X-Amzn-Trace-Id': 'Root=1-62fb87cb-4dbfce250f33864344a762b9',
    'X-Forwarded-For': '62.90.14.41',
    'X-Forwarded-Port': '443',
    'X-Forwarded-Proto': 'https'
  },
  'multiValueHeaders': {
    'Host': [
      'ws.rocket.jitdev.io'
    ],
    'Sec-WebSocket-Extensions': [
      'permessage-deflate; client_max_window_bits'
    ],
    'Sec-WebSocket-Key': [
      'NysmUTUM1SWo5oeJuKHZhw=='
    ],
    'Sec-WebSocket-Version': [
      '13'
    ],
    'X-Amzn-Trace-Id': [
      'Root=1-62fb87cb-4dbfce250f33864344a762b9'
    ],
    'X-Forwarded-For': [
      '62.90.14.41'
    ],
    'X-Forwarded-Port': [
      '443'
    ],
    'X-Forwarded-Proto': [
      'https'
    ]
  },
  'queryStringParameters': {
    'Authorization': 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImVmOGVhMGM0In1.eyJzdWIiOiIyOGFlZWQ3MC01MGNlLTRjZTktODViOC00MDI5M2RmZDliNjQiLCJuYW1lIjoiWW9uYXRhbiBHcmVlbmZlbGQiLCJlbWFpbCI6InlvbmF0aGFuQGppdC5pbyIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJtZXRhZGF0YSI6e30sInJvbGVzIjpbIm1lbWJlciJdLCJwZXJtaXNzaW9ucyI6WyJmZS5zZWN1cmUucmVhZC51c2VycyIsImZlLnNlY3VyZS5yZWFkLioiXSwidGVuYW50SWQiOiJjZTJmNTM1Ny1hYTQzLTRiNTUtYTgzNS1iNjlmOTgwZDBlYmYiLCJ0ZW5hbnRJZHMiOlsiY2UyZjUzNTctYWE0My00YjU1LWE4MzUtYjY5Zjk4MGQwZWJmIl0sInByb2ZpbGVQaWN0dXJlVXJsIjoiaHR0cHM6Ly9hdmF0YXJzLmdpdGh1YnVzZXJjb250ZW50LmNvbS91LzEwMDY4NTM3NT92PTQiLCJzaWQiOiI1NWJlYzVlMi0wMDhkLTQ5NjUtOWYyYi02ZmNjOTU5ODE4MTciLCJ0eXBlIjoidXNlclRva2VuIiwiaWF0IjoxNjYwNjUwMjM5LCJleHAiOjE2NjA3MzY2MzksImF1ZCI6ImVmOGVhMGM0LWRlMWEtNGU5OS1hZDk5LTA4YmZiZTkxMDc5OSIsImlzcyI6Imh0dHBzOi8vaml0LXJvY2tldC5mcm9udGVnZy5jb20ifQ.V7CpF0yE9dUfPHcTRU71OmsflL3EoCzAK25XB1KWrT60o_2ihUhVGuucrOWcR-rgJGXSbl451wBwv36yWkTNG2cvteIDMkHrosPw9XGojrdT_sh6TL7IAuOWEvJnAvI5tqN_eamodlHFBtPUZf7nepzoBzQUDWgUXExE7R6-3KuaihPkr4AgeAvhoU-ToiIac2tE_S5VI6b8nuDjqDfmD6jPNsbuaXVolGSDzdOQGpXxsLiFM4A5-gZa0HY47RVIGAp-ra4qDmJXO9Ou79xPVSwE1R2e9F4Fw_fAE6gyukI7RnHNPzkmFgRI1T7gCXdYNX2Q4ri56QZpNW9aB1RkEQ',
    'AuthId': 'ce2f5357-aa43-4b55-a835-b69f980d0ebf'
  },
  'multiValueQueryStringParameters': {
    'Authorization': [
      'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImVmOGVhMGM0In1.eyJzdWIiOiIyOGFlZWQ3MC01MGNlLTRjZTktODViOC00MDI5M2RmZDliNjQiLCJuYW1lIjoiWW9uYXRhbiBHcmVlbmZlbGQiLCJlbWFpbCI6InlvbmF0aGFuQGppdC5pbyIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJtZXRhZGF0YSI6e30sInJvbGVzIjpbIm1lbWJlciJdLCJwZXJtaXNzaW9ucyI6WyJmZS5zZWN1cmUucmVhZC51c2VycyIsImZlLnNlY3VyZS5yZWFkLioiXSwidGVuYW50SWQiOiJjZTJmNTM1Ny1hYTQzLTRiNTUtYTgzNS1iNjlmOTgwZDBlYmYiLCJ0ZW5hbnRJZHMiOlsiY2UyZjUzNTctYWE0My00YjU1LWE4MzUtYjY5Zjk4MGQwZWJmIl0sInByb2ZpbGVQaWN0dXJlVXJsIjoiaHR0cHM6Ly9hdmF0YXJzLmdpdGh1YnVzZXJjb250ZW50LmNvbS91LzEwMDY4NTM3NT92PTQiLCJzaWQiOiI1NWJlYzVlMi0wMDhkLTQ5NjUtOWYyYi02ZmNjOTU5ODE4MTciLCJ0eXBlIjoidXNlclRva2VuIiwiaWF0IjoxNjYwNjUwMjM5LCJleHAiOjE2NjA3MzY2MzksImF1ZCI6ImVmOGVhMGM0LWRlMWEtNGU5OS1hZDk5LTA4YmZiZTkxMDc5OSIsImlzcyI6Imh0dHBzOi8vaml0LXJvY2tldC5mcm9udGVnZy5jb20ifQ.V7CpF0yE9dUfPHcTRU71OmsflL3EoCzAK25XB1KWrT60o_2ihUhVGuucrOWcR-rgJGXSbl451wBwv36yWkTNG2cvteIDMkHrosPw9XGojrdT_sh6TL7IAuOWEvJnAvI5tqN_eamodlHFBtPUZf7nepzoBzQUDWgUXExE7R6-3KuaihPkr4AgeAvhoU-ToiIac2tE_S5VI6b8nuDjqDfmD6jPNsbuaXVolGSDzdOQGpXxsLiFM4A5-gZa0HY47RVIGAp-ra4qDmJXO9Ou79xPVSwE1R2e9F4Fw_fAE6gyukI7RnHNPzkmFgRI1T7gCXdYNX2Q4ri56QZpNW9aB1RkEQ'
    ],
    'AuthId': [
      'ce2f5357-aa43-4b55-a835-b69f980d0ebf'
    ]
  },
  'requestContext': {
    'routeKey': '$connect',
    'authorizer': {
      'tenant_id': 'ce2f5357-aa43-4b55-a835-b69f980d0ebf',
      'principalId': '28aeed70-50ce-4ce9-85b8-40293dfd9b64',
      'integrationLatency': 21
    },
    'eventType': 'CONNECT',
    'extendedRequestId': 'W9In0EDVIAMFexQ=',
    'requestTime': '16/Aug/2022:12:04:27 +0000',
    'messageDirection': 'IN',
    'stage': 'dev',
    'connectedAt': 1660651467489,
    'requestTimeEpoch': 1660651467493,
    'identity': {
      'sourceIp': '62.90.14.41'
    },
    'requestId': 'W9In0EDVIAMFexQ=',
    'domainName': 'ws.domain.io',
    'connectionId': 'W9In0cvXIAMCFvw=',
    'apiId': 'yldxgyfndc'
  },
  'isBase64Encoded': False
}

```

### Route
```js
{
  'requestContext': {
    'routeKey': '$default',
    'authorizer': {
      'authId': 'ce2f5357-aa43-4b55-a835-b69f980d0ebf',
      'principalId': '28aeed70-50ce-4ce9-85b8-40293dfd9b64'
    },
    'messageId': 'W9Ol9d1PIAMCEbA=',
    'eventType': 'MESSAGE',
    'extendedRequestId': 'W9Ol9HD1oAMFQug=',
    'requestTime': '16/Aug/2022:12:45:13 +0000',
    'messageDirection': 'IN',
    'stage': 'dev',
    'connectedAt': 1660653901917,
    'requestTimeEpoch': 1660653913130,
    'identity': {
      'sourceIp': '62.90.14.41'
    },
    'requestId': 'W9Ol9HD1oAMFQug=',
    'domainName': 'ws.rocket.jitdev.io',
    'connectionId': 'W9OkNdpHIAMCEbA=',
    'apiId': 'yldxgyfndc'
  },
  'body': '{"action": "default"}',
  'isBase64Encoded': False
}
```
