### PR TITLE
Enrich and fix the IAM policy type

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-lambda-typing"
-version = "2.13.1"
+version = "2.14.0"
 description = "A package that provides type hints for AWS Lambda event, context and response objects"
 authors = ["Mousa Zeid Baker"]
 license = "MIT"

--- a/src/aws_lambda_typing/common/iam.py
+++ b/src/aws_lambda_typing/common/iam.py
@@ -3,67 +3,126 @@
 import sys
 
 if sys.version_info >= (3, 8):
-    from typing import Dict, List, Literal, Optional, TypedDict, Union
+    from typing import Dict, List, Literal, TypedDict, Union
 else:
-    from typing import Dict, List, Optional, Union
+    from typing import Dict, List, Union
 
     from typing_extensions import Literal, TypedDict
 
 
-class Statement(TypedDict, total=False):
+class Principal(TypedDict, total=False):
     """
-    Statement
-    https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_statement.html
+    Principal
+    - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html
 
     Attributes:
     ----------
-    Principal: Optional[Union[str, List[str], Dict[str, Union[str, List[str]]]]]
+    AWS: Union[str, List[str]]
 
-    NotPrincipal: Optional[
-        Union[str, List[str], Dict[str, Union[str, List[str]]]]
-    ]
+    CanonicalUser: Union[str, List[str]]
 
-    Action: Optional[Union[str, List[str]]]
+    Federated: Union[str, List[str]]
 
-    NotAction: Optional[Union[str, List[str]]]
+    Service: Union[str, List[str]]
 
-    Resource: Optional[Union[str, List[str]]]
-
-    NotResource: Optional[Union[str, List[str]]]
-
-    Condition: Optional[Dict[str, Dict[str, Union[str, List[str]]]]]
     """
 
-    Sid: Optional[str]
+    AWS: Union[str, List[str]]
+    CanonicalUser: Union[str, List[str]]
+    Federated: Union[str, List[str]]
+    Service: Union[str, List[str]]
+
+
+class _Statement(TypedDict):
+    """
+    Base class used to define required attributes
+    - https://peps.python.org/pep-0589/#totality
+
+    Attributes:
+    ----------
+    Effect: Literal["Allow", "Deny"]
+    - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_effect.html
+    """
+
     Effect: Literal[
         "Allow",
         "Deny",
     ]
-    Principal: Optional[Union[str, List[str], Dict[str, Union[str, List[str]]]]]
-    NotPrincipal: Optional[
-        Union[str, List[str], Dict[str, Union[str, List[str]]]]
-    ]
-    Action: Optional[Union[str, List[str]]]
-    NotAction: Optional[Union[str, List[str]]]
-    Resource: Optional[Union[str, List[str]]]
-    NotResource: Optional[Union[str, List[str]]]
-    Condition: Optional[Dict[str, Dict[str, Union[str, List[str]]]]]
 
 
-class PolicyDocument(TypedDict, total=False):
+class Statement(_Statement, total=False):
     """
-    PolicyDocument
-    https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html
+    Statement
+    - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_statement.html
+
+    Attributes:
+    ----------
+    Sid: str
+    - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_sid.html
+
+    Principal: Union[Literal["*"], :py:class:`Principal`]
+    - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html
+
+    NotPrincipal: :py:class:`Principal`
+    - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_notprincipal.html
+
+    Action: Union[str, List[str]]
+    - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_action.html
+    - At least one of Action/NotAction must be specified
+
+    NotAction: Union[str, List[str]]
+    - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_notaction.html
+    - At least one of Action/NotAction must be specified
+
+    Resource: Union[str, List[str]]
+    - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_resource.html
+    - At least one of Resource/NotResource must be specified
+
+    NotResource: Union[str, List[str]]
+    - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_notresource.html
+    - At least one of Resource/NotResource must be specified
+
+    Condition: Dict[str, Dict[str, Union[str, List[str]]]]
+    - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_condition.html
+    """
+
+    Sid: str
+    Principal: Union[Literal["*"], Principal]
+    NotPrincipal: Principal
+    Action: Union[str, List[str]]
+    NotAction: Union[str, List[str]]
+    Resource: Union[str, List[str]]
+    NotResource: Union[str, List[str]]
+    Condition: Dict[str, Dict[str, Union[str, List[str]]]]
+
+
+class _PolicyDocument(TypedDict):
+    """
+    Base class used to define required attributes
+    - https://peps.python.org/pep-0589/#totality
 
     Attributes:
     ----------
     Version: str
+    - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_version.html
 
-    Id: Optional[str]
-
-    Statement: List[:py:class:`Statement`]
+    Statement: Union[:py:class:`Statement`, List[:py:class:`Statement`]]
+    - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_statement.html
     """
 
-    Version: str
-    Id: Optional[str]
-    Statement: List[Statement]
+    Version: Literal["2012-10-17", "2008-10-17"]
+    Statement: Union[Statement, List[Statement]]
+
+
+class PolicyDocument(_PolicyDocument, total=False):
+    """
+    PolicyDocument
+    - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html
+
+    Attributes:
+    ----------
+    Id: str
+    - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_id.html
+    """
+
+    Id: str

--- a/src/aws_lambda_typing/common/iam.py
+++ b/src/aws_lambda_typing/common/iam.py
@@ -13,7 +13,7 @@ else:
 class Principal(TypedDict, total=False):
     """
     Principal
-     - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html
+    https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html
 
     Attributes:
     ----------
@@ -36,7 +36,7 @@ class Principal(TypedDict, total=False):
 class _Statement(TypedDict):
     """
     Base class used to define required attributes
-    - https://peps.python.org/pep-0589/#totality
+    https://peps.python.org/pep-0589/#totality
 
     """
 
@@ -49,40 +49,31 @@ class _Statement(TypedDict):
 class Statement(_Statement, total=False):
     """
     Statement
-     - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_statement.html
+    https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_statement.html
 
     Attributes:
     ----------
     Effect: Literal["Allow", "Deny"]
-     - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_effect.html
 
     Sid: str
-     - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_sid.html
 
     Principal: Union[Literal["*"], :py:class:`Principal`]
-     - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html
 
     NotPrincipal: :py:class:`Principal`
-     - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_notprincipal.html
 
     Action: Union[str, List[str]]
-     - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_action.html
-     - At least one of Action/NotAction must be specified
+    - At least one of Action/NotAction must be specified
 
     NotAction: Union[str, List[str]]
-     - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_notaction.html
-     - At least one of Action/NotAction must be specified
+    - At least one of Action/NotAction must be specified
 
     Resource: Union[str, List[str]]
-     - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_resource.html
-     - At least one of Resource/NotResource must be specified
+    - At least one of Resource/NotResource must be specified
 
     NotResource: Union[str, List[str]]
-     - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_notresource.html
-     - At least one of Resource/NotResource must be specified
+    - At least one of Resource/NotResource must be specified
 
     Condition: Dict[str, Dict[str, Union[str, List[str]]]]
-     - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_condition.html
     """
 
     Sid: str
@@ -98,7 +89,7 @@ class Statement(_Statement, total=False):
 class _PolicyDocument(TypedDict):
     """
     Base class used to define required attributes
-     - https://peps.python.org/pep-0589/#totality
+    https://peps.python.org/pep-0589/#totality
     """
 
     Version: Literal["2012-10-17", "2008-10-17"]
@@ -108,18 +99,15 @@ class _PolicyDocument(TypedDict):
 class PolicyDocument(_PolicyDocument, total=False):
     """
     PolicyDocument
-     - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html
+    https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html
 
     Attributes:
     ----------
     Version: Literal["2012-10-17", "2008-10-17"]
-     - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_version.html
 
     Statement: Union[:py:class:`Statement`, List[:py:class:`Statement`]]
-     - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_statement.html
 
     Id: str
-     - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_id.html
     """
 
     Id: str

--- a/src/aws_lambda_typing/common/iam.py
+++ b/src/aws_lambda_typing/common/iam.py
@@ -13,7 +13,7 @@ else:
 class Principal(TypedDict, total=False):
     """
     Principal
-    - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html
+     - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html
 
     Attributes:
     ----------
@@ -38,10 +38,6 @@ class _Statement(TypedDict):
     Base class used to define required attributes
     - https://peps.python.org/pep-0589/#totality
 
-    Attributes:
-    ----------
-    Effect: Literal["Allow", "Deny"]
-    - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_effect.html
     """
 
     Effect: Literal[
@@ -53,37 +49,40 @@ class _Statement(TypedDict):
 class Statement(_Statement, total=False):
     """
     Statement
-    - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_statement.html
+     - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_statement.html
 
     Attributes:
     ----------
+    Effect: Literal["Allow", "Deny"]
+     - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_effect.html
+
     Sid: str
-    - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_sid.html
+     - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_sid.html
 
     Principal: Union[Literal["*"], :py:class:`Principal`]
-    - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html
+     - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html
 
     NotPrincipal: :py:class:`Principal`
-    - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_notprincipal.html
+     - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_notprincipal.html
 
     Action: Union[str, List[str]]
-    - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_action.html
-    - At least one of Action/NotAction must be specified
+     - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_action.html
+     - At least one of Action/NotAction must be specified
 
     NotAction: Union[str, List[str]]
-    - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_notaction.html
-    - At least one of Action/NotAction must be specified
+     - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_notaction.html
+     - At least one of Action/NotAction must be specified
 
     Resource: Union[str, List[str]]
-    - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_resource.html
-    - At least one of Resource/NotResource must be specified
+     - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_resource.html
+     - At least one of Resource/NotResource must be specified
 
     NotResource: Union[str, List[str]]
-    - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_notresource.html
-    - At least one of Resource/NotResource must be specified
+     - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_notresource.html
+     - At least one of Resource/NotResource must be specified
 
     Condition: Dict[str, Dict[str, Union[str, List[str]]]]
-    - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_condition.html
+     - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_condition.html
     """
 
     Sid: str
@@ -99,15 +98,7 @@ class Statement(_Statement, total=False):
 class _PolicyDocument(TypedDict):
     """
     Base class used to define required attributes
-    - https://peps.python.org/pep-0589/#totality
-
-    Attributes:
-    ----------
-    Version: str
-    - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_version.html
-
-    Statement: Union[:py:class:`Statement`, List[:py:class:`Statement`]]
-    - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_statement.html
+     - https://peps.python.org/pep-0589/#totality
     """
 
     Version: Literal["2012-10-17", "2008-10-17"]
@@ -117,12 +108,18 @@ class _PolicyDocument(TypedDict):
 class PolicyDocument(_PolicyDocument, total=False):
     """
     PolicyDocument
-    - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html
+     - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html
 
     Attributes:
     ----------
+    Version: Literal["2012-10-17", "2008-10-17"]
+     - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_version.html
+
+    Statement: Union[:py:class:`Statement`, List[:py:class:`Statement`]]
+     - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_statement.html
+
     Id: str
-    - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_id.html
+     - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_id.html
     """
 
     Id: str


### PR DESCRIPTION
Enrich the documentation, and elaborate the `Principal` type. Fix the
usage of `Optional` as a not required key indicator and replace it with
typed dict inheritance as specified in PEP-589.

fixes #66 