### PR TITLE
added optional operationName

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-lambda-typing"
-version = "2.16.0"
+version = "2.16.1"
 description = "A package that provides type hints for AWS Lambda event, context and response objects"
 authors = ["Mousa Zeid Baker"]
 license = "MIT"

--- a/src/aws_lambda_typing/events/api_gateway_proxy.py
+++ b/src/aws_lambda_typing/events/api_gateway_proxy.py
@@ -95,6 +95,8 @@ class RequestContextV1(TypedDict, total=False):
 
     identity: :py:class:`RequestContextIdentity`
 
+    operationName: str
+
     path: str
 
     protocol: str
@@ -120,6 +122,7 @@ class RequestContextV1(TypedDict, total=False):
     extendedRequestId: Optional[str]
     httpMethod: str
     identity: RequestContextIdentity
+    operationName: Optional[str]
     path: str
     protocol: str
     requestId: str

--- a/tests/events/test_api_gateway_proxy.py
+++ b/tests/events/test_api_gateway_proxy.py
@@ -59,6 +59,7 @@ def test_api_gateway_proxy_event_v1() -> None:
             "requestTime": "10/Mar/2020:00:03:59 +0000",
             "path": "/Prod/",
             "accountId": "123456789012",
+            "operationName": "SomeOperation",
             "protocol": "HTTP/1.1",
             "stage": "Prod",
             "domainPrefix": "70ixmpl4fl",


### PR DESCRIPTION
Added optional operationName to the RequestContextV1 structure. This fixes, #72.

See #72 for more details. 