### PR TITLE
fix: add Optional to api gateway event fields that can be null

### DIFF
--- a/src/aws_lambda_typing/events/api_gateway_proxy.py
+++ b/src/aws_lambda_typing/events/api_gateway_proxy.py
@@ -174,11 +174,11 @@ class APIGatewayProxyEventV1(TypedDict):
     requestContext: RequestContextV1
     headers: Dict[str, str]
     multiValueHeaders: Dict[str, List[str]]
-    queryStringParameters: Dict[str, str]
-    multiValueQueryStringParameters: Dict[str, List[str]]
-    pathParameters: Dict[str, str]
-    stageVariables: Dict[str, str]
-    body: str
+    queryStringParameters: Optional[Dict[str, str]]
+    multiValueQueryStringParameters: Optional[Dict[str, List[str]]]
+    pathParameters: Optional[Dict[str, str]]
+    stageVariables: Optional[Dict[str, str]]
+    body: Optional[str]
     isBase64Encoded: bool
 
 


### PR DESCRIPTION
PR addressing this issue: https://github.com/MousaZeidBaker/aws-lambda-typing/issues/79

API Gateway can send back `null` values in the event for select fields. This PR uses the `Optional` type hint to reflect that these values may exist, or may be null.