### PR TITLE
fix: make APIGatewayProxyResponseV1 total=False

### DIFF
--- a/src/aws_lambda_typing/responses/api_gateway_proxy.py
+++ b/src/aws_lambda_typing/responses/api_gateway_proxy.py
@@ -17,7 +17,7 @@ else:
 """
 
 
-class APIGatewayProxyResponseV1(TypedDict):
+class APIGatewayProxyResponseV1(TypedDict, total=False):
     """
     APIGatewayProxyResponseV1
     https://docs.aws.amazon.com/lambda/latest/dg/services-apigateway.html


### PR DESCRIPTION
All the response keys are not required and will get default values if not present.

fixes: #85 