### PR TITLE
test: fix test function names

### DIFF
--- a/tests/common/test_iam.py
+++ b/tests/common/test_iam.py
@@ -1,7 +1,7 @@
 from aws_lambda_typing.common import PolicyDocument
 
 
-def test_s3_batch_response() -> None:
+def iam_policy_document() -> None:
     document: PolicyDocument = {
         "Version": "2012-10-17",
         "Statement": [

--- a/tests/events/test_apache_kafka.py
+++ b/tests/events/test_apache_kafka.py
@@ -1,7 +1,7 @@
 from aws_lambda_typing.events import ApacheKafkaEvent
 
 
-def test_msk_event() -> None:
+def test_apache_kafka_event() -> None:
     event: ApacheKafkaEvent = {
         "eventSource": "SelfManagedKafka",
         "bootstrapServers": "myserver.local:9092",

--- a/tests/events/test_event_bridge.py
+++ b/tests/events/test_event_bridge.py
@@ -1,7 +1,7 @@
 from aws_lambda_typing.events import EventBridgeEvent
 
 
-def test_cloud_watch_events_message_event() -> None:
+def test_event_bridge_event() -> None:
     event: EventBridgeEvent = {
         "version": "0",
         "id": "fe8d3c65-xmpl-c5c3-2c87-81584709a377",

--- a/tests/responses/test_dynamodb_batch.py
+++ b/tests/responses/test_dynamodb_batch.py
@@ -1,7 +1,7 @@
 from aws_lambda_typing.responses import DynamoDBBatchResponse
 
 
-def test_s3_batch_response() -> None:
+def test_dynamodb_batch_response() -> None:
     response: DynamoDBBatchResponse = {
         "batchItemFailures": [
             {


### PR DESCRIPTION
Some of the test function names did not match the "type" they were testing. Among them, there were some that still had names copied and pasted from other tests.

To avoid confusion, I've suggested some potential corrections to the names. If the maintainers find a better naming convention, please feel free to make adjustments.