### PR TITLE
feat: add EC2 Auto Scaling Group custom termination policy event

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ def handler(event: events.SQSEvent, context: context_.Context) -> None:
 - ConfigEvent
 - DynamoDBStreamEvent
 - EventBridgeEvent
+- EC2ASGCustomTerminationPolicyEvent
 - IoTPreProvisioningHookEvent
 - KinesisFirehoseEvent
 - KinesisStreamEvent

--- a/src/aws_lambda_typing/events/__init__.py
+++ b/src/aws_lambda_typing/events/__init__.py
@@ -53,6 +53,9 @@ from .cognito_custom_message import (
 )
 from .config import ConfigEvent as ConfigEvent
 from .dynamodb_stream import DynamoDBStreamEvent as DynamoDBStreamEvent
+from .ec2_asg_custom_termination_policy import (
+    EC2ASGCustomTerminationPolicyEvent as EC2ASGCustomTerminationPolicyEvent,
+)
 from .event_bridge import EventBridgeEvent as EventBridgeEvent
 from .iot import IoTPreProvisioningHookEvent as IoTPreProvisioningHookEvent
 from .kinesis_firehose import KinesisFirehoseEvent as KinesisFirehoseEvent

--- a/src/aws_lambda_typing/events/ec2_asg_custom_termination_policy.py
+++ b/src/aws_lambda_typing/events/ec2_asg_custom_termination_policy.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+
+import sys
+
+if sys.version_info >= (3, 8):
+    from typing import List, Literal, TypedDict
+else:
+    from typing import List
+
+    from typing_extensions import Literal, TypedDict
+
+
+class Capacity(TypedDict):
+    """
+    Capacity
+
+    Attributes:
+    ----------
+    AvailabilityZone: str
+
+    Capacity: int
+
+    InstanceMarketOption: Literal['on-demand', 'spot']
+    """
+
+    AvailabilityZone: str
+    Capacity: int
+    InstanceMarketOption: Literal[
+        "on-demand",
+        "spot",
+    ]
+
+
+class Instance(TypedDict):
+    """
+    Instance
+
+    Attributes:
+    ----------
+    AvailabilityZone: str
+
+    InstanceId: str
+
+    InstanceType: str
+
+    InstanceMarketOption: Literal['on-demand', 'spot']
+    """
+
+    AvailabilityZone: str
+    InstanceId: str
+    InstanceType: str
+    InstanceMarketOption: Literal[
+        "on-demand",
+        "spot",
+    ]
+
+
+class EC2ASGCustomTerminationPolicyEvent(TypedDict):
+    """
+    EC2ASGCustomTerminationPolicyEvent
+    https://docs.aws.amazon.com/autoscaling/ec2/userguide/lambda-custom-termination-policy.html
+
+    Attributes:
+    ----------
+    AutoScalingGroupARN: str
+
+    AutoScalingGroupName: str
+
+    CapacityToTerminate: List[:py:class:`CapacityToTerminate`]
+
+    Instances: List[:py:class:`Instances`]
+
+    Cause: Literal[
+        'SCALE_IN',
+        'INSTANCE_REFRESH',
+        'MAX_INSTANCE_LIFETIME',
+        'REBALANCE'
+    ]
+    """
+
+    AutoScalingGroupARN: str
+    AutoScalingGroupName: str
+    CapacityToTerminate: List[Capacity]
+    Instances: List[Instance]
+    Cause: Literal[
+        "SCALE_IN",
+        "INSTANCE_REFRESH",
+        "MAX_INSTANCE_LIFETIME",
+        "REBALANCE",
+    ]

--- a/tests/events/test_ec2_asg_custom_termination_policy.py
+++ b/tests/events/test_ec2_asg_custom_termination_policy.py
@@ -1,0 +1,83 @@
+from aws_lambda_typing.events import EC2ASGCustomTerminationPolicyEvent
+
+
+def test_ec2_asg_custom_termination_policy_event_pattern1() -> None:
+    # Event from AWS documentation
+    # https://docs.aws.amazon.com/autoscaling/ec2/userguide/lambda-custom-termination-policy.html
+    event: EC2ASGCustomTerminationPolicyEvent = {
+        "AutoScalingGroupARN": "arn:aws:autoscaling:us-east-1:<account-id>:autoScalingGroup:d4738357-2d40-4038-ae7e-b00ae0227003:autoScalingGroupName/my-asg",  # noqa: E501
+        "AutoScalingGroupName": "my-asg",
+        "CapacityToTerminate": [
+            {
+                "AvailabilityZone": "us-east-1b",
+                "Capacity": 2,
+                "InstanceMarketOption": "on-demand",
+            },
+            {
+                "AvailabilityZone": "us-east-1b",
+                "Capacity": 1,
+                "InstanceMarketOption": "spot",
+            },
+            {
+                "AvailabilityZone": "us-east-1c",
+                "Capacity": 3,
+                "InstanceMarketOption": "on-demand",
+            },
+        ],
+        "Instances": [
+            {
+                "AvailabilityZone": "us-east-1b",
+                "InstanceId": "i-0056faf8da3e1f75d",
+                "InstanceType": "t2.nano",
+                "InstanceMarketOption": "on-demand",
+            },
+            {
+                "AvailabilityZone": "us-east-1c",
+                "InstanceId": "i-02e1c69383a3ed501",
+                "InstanceType": "t2.nano",
+                "InstanceMarketOption": "on-demand",
+            },
+            {
+                "AvailabilityZone": "us-east-1c",
+                "InstanceId": "i-036bc44b6092c01c7",
+                "InstanceType": "t2.nano",
+                "InstanceMarketOption": "on-demand",
+            },
+        ],
+        "Cause": "SCALE_IN",
+    }
+
+
+def test_ec2_asg_custom_termination_policy_event_pattern2() -> None:
+    # Real event observed on 2023/08/17
+    event: EC2ASGCustomTerminationPolicyEvent = {
+        "AutoScalingGroupARN": "arn:aws:autoscaling:ap-northeast-1:480046787332:autoScalingGroup:77727a8f-46ed-4afd-beb6-043e14f8fb40:autoScalingGroupName/test",  # noqa: E501
+        "AutoScalingGroupName": "test",
+        "CapacityToTerminate": [
+            {
+                "AvailabilityZone": "ap-northeast-1a",
+                "Capacity": 1,
+                "InstanceMarketOption": "on-demand",
+            },
+            {
+                "AvailabilityZone": "ap-northeast-1c",
+                "Capacity": 1,
+                "InstanceMarketOption": "on-demand",
+            },
+        ],
+        "Instances": [
+            {
+                "AvailabilityZone": "ap-northeast-1c",
+                "InstanceId": "i-06f811125f96a0d92",
+                "InstanceType": "t4g.small",
+                "InstanceMarketOption": "on-demand",
+            },
+            {
+                "AvailabilityZone": "ap-northeast-1a",
+                "InstanceId": "i-0cb2107f121e6b3ed",
+                "InstanceType": "t4g.small",
+                "InstanceMarketOption": "on-demand",
+            },
+        ],
+        "Cause": "SCALE_IN",
+    }


### PR DESCRIPTION
In EC2 Auto Scaling Groups (ASG), we can set a custom termination policy. When doing so, we need to write a Lambda function to handle the termination events. The format of the event to this Lambda is defined by AWS.

https://docs.aws.amazon.com/autoscaling/ec2/userguide/lambda-custom-termination-policy.html

I've created a "type" that corresponds to this event. I'd be grateful if you could consider merging it.