### PR TITLE
Improve APIGatewayProxyResponseV1

### DIFF
--- a/src/aws_lambda_typing/responses/api_gateway_proxy.py
+++ b/src/aws_lambda_typing/responses/api_gateway_proxy.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
 
 import sys
+from typing import Dict, List, Union
 
 if sys.version_info >= (3, 8):
-    from typing import Dict, List, TypedDict
+    from typing import TypedDict
 else:
-    from typing import Dict, List
-
     from typing_extensions import TypedDict
 
 
@@ -42,7 +41,7 @@ class APIGatewayProxyResponseV1(TypedDict, total=False):
     statusCode: int
     headers: Dict[str, str]
     multiValueHeaders: Dict[str, List[str]]
-    body: str
+    body: Union[str, bytes]
 
 
 """

--- a/src/aws_lambda_typing/responses/api_gateway_proxy.py
+++ b/src/aws_lambda_typing/responses/api_gateway_proxy.py
@@ -8,6 +8,10 @@ if sys.version_info >= (3, 8):
 else:
     from typing_extensions import TypedDict
 
+if sys.version_info >= (3, 11):
+    from typing import Required
+else:
+    from typing_extensions import Required
 
 """
 ###############################################################################
@@ -38,7 +42,7 @@ class APIGatewayProxyResponseV1(TypedDict, total=False):
     """
 
     isBase64Encoded: bool
-    statusCode: int
+    statusCode: Required[int]
     headers: Dict[str, str]
     multiValueHeaders: Dict[str, List[str]]
     body: Union[str, bytes]


### PR DESCRIPTION
1. `statusCode` is a mandatory field for the response to the APIGateway V1 (and the only one in this response).
2. The `body` of the response could be from the type `bytes` too, not just `str`.