### PR TITLE
Support for AWS Cognito Post Confirmation Lambda events

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ def handler(event: events.SQSEvent, context: context_.Context) -> None:
 - CodeCommitMessageEvent
 - CodePipelineEvent
 - CognitoCustomMessageEvent
+- CognitoPostConfirmationEvent
 - ConfigEvent
 - DynamoDBStreamEvent
 - EventBridgeEvent

--- a/src/aws_lambda_typing/events/__init__.py
+++ b/src/aws_lambda_typing/events/__init__.py
@@ -51,6 +51,15 @@ from .cognito_custom_message import (
 from .cognito_custom_message import (
     CognitoCustomMessageVerifyUserAttributeEvent as CognitoCustomMessageVerifyUserAttributeEvent,
 )
+from .cognito_post_confirmation import (
+    CognitoPostConfirmationEvent as CognitoPostConfirmationEvent,
+)
+from .cognito_post_confirmation import (
+    CognitoPostConfirmationForgotPasswordEvent as CognitoPostConfirmationForgotPasswordEvent,
+)
+from .cognito_post_confirmation import (
+    CognitoPostConfirmationSignUpEvent as CognitoPostConfirmationSignUpEvent,
+)
 from .config import ConfigEvent as ConfigEvent
 from .dynamodb_stream import DynamoDBStreamEvent as DynamoDBStreamEvent
 from .ec2_asg_custom_termination_policy import (

--- a/src/aws_lambda_typing/events/cognito_post_confirmation.py
+++ b/src/aws_lambda_typing/events/cognito_post_confirmation.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python
+
+import sys
+
+if sys.version_info >= (3, 8):
+    from typing import Any, Dict, Literal, Optional, TypedDict, Union
+else:
+    from typing import Any, Dict, Optional, Union
+
+    from typing_extensions import Literal, TypedDict
+
+
+class CallerContext(TypedDict):
+    """
+    CallerContext
+
+    Attributes:
+    ----------:
+    awsSdkVersion: str
+
+    clientId: str
+    """
+
+    awsSdkVersion: str
+    clientId: str
+
+
+class Request(TypedDict, total=False):
+    """
+    Request
+
+    Attributes:
+    ----------:
+    userAttributes: Dict[str, Any]
+
+    clientMetadata: Optional[Dict[str, Any]]
+    """
+
+    userAttributes: Dict[str, Any]
+    clientMetadata: Optional[Dict[str, Any]]
+
+
+class Response(TypedDict):
+    """
+    Response
+    """
+
+    pass
+
+
+class CognitoPostConfirmationCommon(TypedDict):
+    """
+    CognitoPostConfirmationCommon
+    https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-identity-pools-working-with-aws-lambda-triggers.html#cognito-user-pools-lambda-trigger-syntax-shared
+
+    Attributes:
+    ----------
+    version: str
+
+    region: str
+
+    userPoolId: str
+
+    userName: str
+
+    callerContext: :py:class:`CallerContext`
+
+    request: :py:class:`Request`
+
+    response: :py:class:`Response`
+    """
+
+    version: str
+    region: str
+    userPoolId: str
+    userName: str
+    callerContext: CallerContext
+    request: Request
+    response: Response
+
+
+class CognitoPostConfirmationForgotPasswordEvent(
+    CognitoPostConfirmationCommon,
+):
+    """
+    CognitoPostConfirmationForgotPasswordEvent
+    https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-post-confirmation.html
+
+    Attributes:
+    ----------
+    triggerSource: Literal['PostConfirmation_ConfirmForgotPassword']
+    """
+
+    triggerSource: Literal["PostConfirmation_ConfirmForgotPassword"]
+
+
+class CognitoPostConfirmationSignUpEvent(
+    CognitoPostConfirmationCommon,
+):
+    """
+    CognitoPostConfirmationSignUpEvent
+    https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-post-confirmation.html
+
+    Attributes:
+    ----------
+    triggerSource: Literal['PostConfirmation_ConfirmSignUp']
+    """
+
+    triggerSource: Literal["PostConfirmation_ConfirmSignUp"]
+
+
+CognitoPostConfirmationEvent = Union[
+    CognitoPostConfirmationForgotPasswordEvent,
+    CognitoPostConfirmationSignUpEvent,
+]
+"""
+CognitoPostConfirmationEvent
+https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-post-confirmation.html
+
+Attributes:
+----------
+version: str
+
+triggerSource: Literal[
+    "PostConfirmation_ConfirmForgotPassword",
+    "PostConfirmation_ConfirmSignUp"
+]
+
+region: str
+
+userPoolId: str
+
+userName: str
+
+callerContext: :py:class:`CallerContext`
+
+request: :py:class:`Request`
+
+response: :py:class:`Response`
+"""

--- a/tests/events/test_cognito_post_confirmation.py
+++ b/tests/events/test_cognito_post_confirmation.py
@@ -1,0 +1,54 @@
+from aws_lambda_typing.events import (
+    CognitoPostConfirmationForgotPasswordEvent,
+    CognitoPostConfirmationSignUpEvent,
+)
+
+
+def test_cognito_post_confirmation_forgot_password_event() -> None:
+    event: CognitoPostConfirmationForgotPasswordEvent = {
+        "version": "1",
+        "triggerSource": "PostConfirmation_ConfirmForgotPassword",
+        "region": "us-west-2",
+        "userPoolId": "poolid",
+        "userName": "userName",
+        "callerContext": {
+            "awsSdkVersion": "1",
+            "clientId": "jkSDFasdfnsq",
+        },
+        "request": {
+            "userAttributes": {
+                "sub": "cc0a8a56-9b57-4cd1-a92e-e020bf6d3ab0",
+                "given_name": "John",
+                "family_name": "Doe",
+            },
+            "clientMetadata": {
+                "environment": "development",
+            },
+        },
+        "response": {},
+    }
+
+
+def test_cognito_post_confirmation_sign_up_event() -> None:
+    event: CognitoPostConfirmationSignUpEvent = {
+        "version": "1",
+        "triggerSource": "PostConfirmation_ConfirmSignUp",
+        "region": "us-west-2",
+        "userPoolId": "poolid",
+        "userName": "userName",
+        "callerContext": {
+            "awsSdkVersion": "1",
+            "clientId": "jkSDFasdfnsq",
+        },
+        "request": {
+            "userAttributes": {
+                "sub": "cc0a8a56-9b57-4cd1-a92e-e020bf6d3ab0",
+                "given_name": "John",
+                "family_name": "Doe",
+            },
+            "clientMetadata": {
+                "environment": "development",
+            },
+        },
+        "response": {},
+    }


### PR DESCRIPTION
Hi!

I've been using the project at work and find it incredibly helpful.
However, I noticed that [AWS Cognito Post Confirmation Lambda trigger events](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-post-confirmation.html) are currently not supported.
To address this, I am submitting a pull request to add support for said events. 

Looking forward to your feedback 🙂